### PR TITLE
Update plugin.json for Matomo 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 
+* 5.0.0 Compatibility with Matomo 5
 * 1.4.0 FIX call doIgnore second time will enable tracking again, Mention web component in FAQ, Fix some jQuery demo
   issues
 * 1.3.1 Updated Changelog for release 1.3.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "name":        "AjaxOptOut",
     "description": "Provide endpoints to opt-out, opt-in or get status of visitors tracking. So you can implement a custom HTML, CSS and JS to realize custom-style tracking management.",
-    "version":     "",
+    "version":     "5.0.0",
     "theme":       false,
     "require": {
-        "piwik": ">=3.0.0,<5.0.0",
+        "piwik": ">=5.0.0-b1,<6.0.0-b1",
         "php":   ">=5.6.0"
     },
     "authors":     [


### PR DESCRIPTION
Dear Matomo Plugin Author,
We are excited that Matomo 5.0.0 is on the horizon, and we would greatly appreciate your assistance in ensuring that your plugin remains compatible with this upcoming release. Maintaining compatibility will enable Matomo users to seamlessly use your plugin after they upgrade to Matomo 5. (If the plugin is not updated to be compatible with Matomo 5, then whenever a user will upgrade to Matomo 5, the plugin would be automatically disabled to prevent issues.)

Updating your plugin to be Matomo 5 compatible is a straightforward process and should not require a significant time investment. You can find more information about updating your plugin at: https://developer.matomo.org/guides/migrate-matomo-4-to-5

Thank you for your ongoing support and commitment to the Matomo community. 
Your contribution is really appreciated!

The Matomo Team

PS: we’re also available to help if you have any question about making the plugin compatible.

> I took the liberty of forking this project and making the necessary changes. If you create a `5.x-dev` branch, rebase this PR to that branch, merge the PR, and create a new release, you should be good to go. **NOTE:** The reason I advise creating a new `5.x-dev` branch instead of merging into master is so that you can continue to maintain your plugin for older versions of Matomo.